### PR TITLE
Improved recording stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ The audio library AudioPlaySdWav object is unfortunately one of those that doesn
 You can monitor the time taken for SD card writes by defining the symbol `INSTRUMENT_SD_WRITE`. This is disabled by default, but a line ready for easy editing can be found near the top of the main sketch file. Ideally writes should take significantly less than 6000µs without audio tweaks, or 12000µs with them. Worst-case write times are output every 0.25s.
 
 ---
-**Modifications by h4yn0nnym0u5e, October 27th 2022:**
-* modifications to improve recording reliability
+**Modifications by h4yn0nnym0u5e, October 27th-30th 2022:**
+* modifications to improve recording reliability:
+  * write in larger chunks
+  * use bigger audio blocks to increase update period
+  * disable MTP by default (can be re-enabled without re-programming)
 * corrected WAV header writes to make chunk lengths correct
+* optional code to determine SD card write time
 
 **Modifications by DD4WH, August 1st, 2022:**
 * recordings are now saved as WAV files

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Open the audio guestbook sketch, ensure you have the correct Teensy options set,
 
 For most audio projects, leave Audio tweaks set to `Normal`, as the audio library isn't fully tested with 256-sample blocks.
 
+_DO NOT_ copy the `play_wav_sd.cpp` and `.h` files to your Audio library: They _should_ appear as extra tabs in your Arduino IDE, but are _only_ of use for this project and _will_ break other audio applications using SD playback!
+
 ### Technical stuff
 As noted above, the tweaks work by increasing the number of audio samples in an "audio block" from 128 to 256. This means that audio updates run every 5.8ms rather than the standard 2.9ms, with the consequence that an SD write can take nearly 12ms before an update is "lost". It would be better to figure out how to prevent the SD card write from masking interrupts, but I'm clearly not quite smart enough...
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The audio guestbook is a converted telephone handset that guests can use to leav
 Watch the full step-by-step tutorial on how to use the code here to build your own at https://youtu.be/dI6ielrP1SE
  
  ---
+## Enabling MTP at run-time
+In some cases, the MTP capability (allowing file transfer without removing the SD card) seems to interfere with recording. MTP is thus _disabled_ by default, but can be enabled by holding down the playback button when powering up. A suitable message is sent to the serial monitor so you can see if it's been enabled or not.
 ## Audio tweaks
 ### Background
 The "modifications by h4yn0nnym0u5e, October 27th 2022" work significantly better if the audio library is "tweaked" to use larger data blocks and thus less-frequent audio updates. This allows more time for an SD card write before an interrupt is missed and audio data are lost.
@@ -24,10 +26,13 @@ For most audio projects, leave Audio tweaks set to `Normal`, as the audio librar
 
 _DO NOT_ copy the `play_wav_sd.cpp` and `.h` files to your Audio library: They _should_ appear as extra tabs in your Arduino IDE, but are _only_ of use for this project and _will_ break other audio applications using SD playback!
 
-### Technical stuff
+## Technical stuff
+### Tweaks
 As noted above, the tweaks work by increasing the number of audio samples in an "audio block" from 128 to 256. This means that audio updates run every 5.8ms rather than the standard 2.9ms, with the consequence that an SD write can take nearly 12ms before an update is "lost". It would be better to figure out how to prevent the SD card write from masking interrupts, but I'm clearly not quite smart enough...
 
 The audio library AudioPlaySdWav object is unfortunately one of those that doesn't work well with anything other than a standard 128-sample audio block. Therefore, a (renamed) copy which _does_ work properly is now included within the sketch folder, and used instead of the stock object.
+### Instrumented SD writes
+You can monitor the time taken for SD card writes by defining the symbol `INSTRUMENT_SD_WRITE`. This is disabled by default, but a line ready for easy editing can be found near the top of the main sketch file. Ideally writes should take significantly less than 6000µs without audio tweaks, or 12000µs with them. Worst-case write times are output every 0.25s.
 
 ---
 **Modifications by h4yn0nnym0u5e, October 27th 2022:**

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 The audio guestbook is a converted telephone handset that guests can use to leave recorded messages at weddings, parties and other events, as sold by companies such as "After the Tone", "Fête Fone", "Life on Record", "At the Beep", and others.
 
 Watch the full step-by-step tutorial on how to use the code here to build your own at https://youtu.be/dI6ielrP1SE
+ 
+ ---
+## Audio tweaks
+### Background
+The "modifications by h4yn0nnym0u5e, October 27th 2022" work significantly better if the audio library is "tweaked" to use larger data blocks and thus less-frequent audio updates. This allows more time for an SD card write before an interrupt is missed and audio data are lost.
+### Installation method
+Unfortunately, "installation" is a bit messy, but you only have to do it once (unless you update your Arduino IDE or Teensyduino). The guestbook sketch folder contains two Arduino architecture configuration files, `boards.local.txt` and`platform.txt`. These must be used to update your existing configuration files; in Windows systems these will typically be in `C:\Program Files (x86)\Arduino\hardware\teensy\avr` [todo: where are they on Linux and Mac?].
+
+Before you do anything else, **_back up the existing configuration files_**! Then, make sure all running copies of the Arduino IDE are closed.
+
+The content of `boards.local.txt` should be merged with the existing file; if you don't have one, just copy this file in.
+
+You can either replace the existing `platform.txt` with the new one, or if the existing one looks _very_ different, try to edit it to include all four references to `build.flags.audio`, in similar locations to those found in the replacement file. 
+
+Once the configuration files have been amended, run the Arduino IDE and look at the Tools menu. All being well, you will see a new "Audio tweaks" setting available, with options `Normal` and `Bigger blocks (256 samples)`.
+### In use
+Open the audio guestbook sketch, ensure you have the correct Teensy options set, and set "Audio tweaks" to the `Bigger blocks (256 samples)` option. Upload as usual, and check that there's a message on the Serial console which says "Audio block set to 256 samples". If this is present, the tweaks installation is successful, and you should find your audio recordings less prone to glitches and dropouts. You should still use a decent SD card, and format it "properly" - there's plenty of guidance in the Teensy forum.
+
+For most audio projects, leave Audio tweaks set to `Normal`, as the audio library isn't fully tested with 256-sample blocks.
+
+### Technical stuff
+As noted above, the tweaks work by increasing the number of audio samples in an "audio block" from 128 to 256. This means that audio updates run every 5.8ms rather than the standard 2.9ms, with the consequence that an SD write can take nearly 12ms before an update is "lost". It would be better to figure out how to prevent the SD card write from masking interrupts, but I'm clearly not quite smart enough...
+
+---
+**Modifications by h4yn0nnym0u5e, October 27th 2022:**
+* modifications to improve recording reliability
+* corrected WAV header writes to make chunk lengths correct
 
 **Modifications by DD4WH, August 1st, 2022:**
 * recordings are now saved as WAV files

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For most audio projects, leave Audio tweaks set to `Normal`, as the audio librar
 ### Technical stuff
 As noted above, the tweaks work by increasing the number of audio samples in an "audio block" from 128 to 256. This means that audio updates run every 5.8ms rather than the standard 2.9ms, with the consequence that an SD write can take nearly 12ms before an update is "lost". It would be better to figure out how to prevent the SD card write from masking interrupts, but I'm clearly not quite smart enough...
 
+The audio library AudioPlaySdWav object is unfortunately one of those that doesn't work well with anything other than a standard 128-sample audio block. Therefore, a (renamed) copy which _does_ work properly is now included within the sketch folder, and used instead of the stock object.
+
 ---
 **Modifications by h4yn0nnym0u5e, October 27th 2022:**
 * modifications to improve recording reliability

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The audio guestbook is a converted telephone handset that guests can use to leav
 Watch the full step-by-step tutorial on how to use the code here to build your own at https://youtu.be/dI6ielrP1SE
  
  ---
-## Enabling MTP at run-time
-In some cases, the MTP capability (allowing file transfer without removing the SD card) seems to interfere with recording. MTP is thus _disabled_ by default, but can be enabled by holding down the playback button when powering up. A suitable message is sent to the serial monitor so you can see if it's been enabled or not.
+## Disabled MTP during recording
+In some cases, the MTP capability (allowing file transfer without removing the SD card) seems to interfere with recording. MTP medium-change checking is thus _disabled_ during recording. A suitable message is sent to the serial monitor so you can see when it's been enabled.
 ## Audio tweaks
 ### Background
 The "modifications by h4yn0nnym0u5e, October 27th 2022" work significantly better if the audio library is "tweaked" to use larger data blocks and thus less-frequent audio updates. This allows more time for an SD card write before an interrupt is missed and audio data are lost.
@@ -39,7 +39,7 @@ You can monitor the time taken for SD card writes by defining the symbol `INSTRU
 * modifications to improve recording reliability:
   * write in larger chunks
   * use bigger audio blocks to increase update period
-  * disable MTP by default (can be re-enabled without re-programming)
+  * disable MTP medium change checks during recording
 * corrected WAV header writes to make chunk lengths correct
 * optional code to determine SD card write time
 
@@ -50,7 +50,7 @@ You can monitor the time taken for SD card writes by defining the symbol `INSTRU
 * playback only plays the very last recorded file, not ALL the files ever recorded
 * does not play the greeting message again when you want to listen to your recordings
 * some bugfixes and warnings eliminated
-* do not forget that your greeting message has to be recorded as a wav with a sample rate of 44.1ksps, otherwise it is not played
+* do not forget that your greeting message has to be recorded as a WAV with a sample rate of 44.1ksps, otherwise it is not played
 * compile the code with CPU speed 150MHz, this can save a lot of battery power (reduction by about 70%)
 
 **DD4WH hardware:**

--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -260,7 +260,6 @@ void continueRecording() {
 #define NBLOX 16  
   // Check if there is data in the queue
   if (queue1.available() >= NBLOX) {
-    byte buffer[512];
     byte buffer[NBLOX*AUDIO_BLOCK_SAMPLES*sizeof(int16_t)];
     // Fetch 2 blocks from the audio library and copy
     // into a 512 byte buffer.  The Arduino SD library

--- a/boards.local.txt
+++ b/boards.local.txt
@@ -1,0 +1,15 @@
+# Copy these lines into your boards.local.txt, OR if you don't have one,
+# copy this whole file into the same folder as your boards.txt file.
+#
+# On a Windows system this will typically be in:
+#   C:\Program Files (x86)\Arduino\hardware\teensy\avr
+#
+menu.audiotune=Audio tweaks
+teensy41.menu.audiotune.normal=Normal
+teensy41.menu.audiotune.normal.build.flags.audio=-DAUDIO_BLOCK_SAMPLES=128
+teensy41.menu.audiotune.bigger=Bigger blocks (256 samples)
+teensy41.menu.audiotune.bigger.build.flags.audio=-DAUDIO_BLOCK_SAMPLES=256
+teensy40.menu.audiotune.normal=Normal
+teensy40.menu.audiotune.normal.build.flags.audio=-DAUDIO_BLOCK_SAMPLES=128
+teensy40.menu.audiotune.bigger=Bigger blocks (256 samples)
+teensy40.menu.audiotune.bigger.build.flags.audio=-DAUDIO_BLOCK_SAMPLES=256

--- a/platform.txt
+++ b/platform.txt
@@ -1,0 +1,131 @@
+# https://www.pjrc.com/teensy/td_download.html
+# https://arduino.github.io/arduino-cli/latest/platform-specification/
+# https://arduino.github.io/arduino-cli/0.19/platform-specification/
+
+# Modified platform.txt to allow use of audio-specific build flags when used with the
+# Teensy audio library. Make a copy of your existing platform.txt first! Then either
+# (a) overwrite platform.txt with this file, or
+# (b) hand-edit your platform.txt to include the references to build.flags.audio;
+#     there are 4 of these, in lines 26, 47, 50 and 56
+#
+# On a Windows system platform.txt will typically be in:
+#   C:\Program Files (x86)\Arduino\hardware\teensy\avr
+
+name=Teensyduino
+version=1.8.5
+rewriting=disabled
+
+# Teensyduino Installer
+compiler.path={runtime.hardware.path}/../tools/
+teensytools.path={runtime.hardware.path}/../tools/
+
+# Arduino Boards Manager
+#compiler.path={runtime.tools.teensy-compile.path}/
+#teensytools.path={runtime.tools.teensy-tools.path}/
+
+build.flags.audio=-DAUDIO_BLOCK_SAMPLES=128
+
+## EEPROM Data
+compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
+compiler.elf2hex.flags=-O ihex -R .eeprom
+
+## Preprocessor Includes
+recipe.preproc.includes="{compiler.path}{build.toolchain}{build.command.g++}" -M -MG -MP -x c++ -w {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}"
+
+## Preprocessor Macros
+recipe.preproc.macros="{compiler.path}{build.toolchain}{build.command.g++}" -E -CC -x c++ -w {compiler.cpp.flags} {build.flags.common} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}" -o "{preprocessed_file_path}"
+
+## New Preprocessor for Arduino 1.9
+tools.arduino-preprocessor.path={runtime.tools.arduino-preprocessor.path}
+tools.arduino-preprocessor.cmd.path={path}/arduino-preprocessor
+tools.arduino-preprocessor.pattern="{cmd.path}" "{source_file}" "{codecomplete}" -- -std=gnu++14
+
+## Precompile Arduino.h header
+recipe.hooks.sketch.prebuild.1.pattern="{teensytools.path}precompile_helper" "{runtime.platform.path}/cores/{build.core}" "{build.path}" "{compiler.path}{build.toolchain}{build.command.g++}" -x c++-header {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{runtime.platform.path}/cores/{build.core}" "{build.path}/pch/Arduino.h" -o "{build.path}/pch/Arduino.h.gch"
+
+## Compile c++ files
+recipe.cpp.o.pattern="{compiler.path}{build.toolchain}{build.command.g++}" -c {build.flags.audio} {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{build.path}/pch" {includes} "{source_file}" -o "{object_file}"
+
+## Compile c files
+recipe.c.o.pattern="{compiler.path}{build.toolchain}{build.command.gcc}" -c {build.flags.audio} {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.c} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}" -o "{object_file}"
+
+## Compile S files
+recipe.S.o.pattern="{compiler.path}{build.toolchain}{build.command.gcc}" -c {build.flags.audio} {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.S} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}" -o "{object_file}"
+
+## Create archives
+recipe.ar.pattern="{compiler.path}{build.toolchain}{build.command.ar}" rcs "{archive_file_path}" "{object_file}"
+
+## Link
+recipe.c.combine.pattern="{compiler.path}{build.toolchain}{build.command.linker}" {build.flags.optimize} {build.flags.ld} {build.flags.ldspecs} {build.flags.cpu} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" {build.flags.libs}
+
+## Patch ELF - TODO: not supported by modern Arduino...  :(
+recipe.elfpatch.pattern="{teensytools.path}/{build.elfpatch}" -mmcu={build.mcu} "{build.path}/{build.project_name}.elf" "{sketch_path}/disk"
+
+## Create eeprom
+recipe.objcopy.eep.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.objcopy.eep.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"
+
+## Create hex
+recipe.objcopy.hex.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.elf2hex.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
+
+## EHEX file - for Teensy 4.x secure mode
+recipe.hooks.objcopy.postobjcopy.1.pattern="{teensytools.path}teensy_secure" encrypthex {build.board} "{build.path}/{build.project_name}.hex"
+
+
+## Post Build - inform Teensy Loader of new file
+recipe.hooks.postbuild.1.pattern="{teensytools.path}teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={teensytools.path}" "-board={build.board}"
+recipe.hooks.postbuild.2.pattern="{teensytools.path}stdout_redirect" "{build.path}/{build.project_name}.sym" "{compiler.path}{build.toolchain}{build.command.objdump}" -t -C "{build.path}/{build.project_name}.elf"
+recipe.hooks.postbuild.3.pattern="{teensytools.path}teensy_size" "{build.path}/{build.project_name}.elf"
+#
+# objdump to create .lst file is VERY SLOW for huge files
+# https://forum.pjrc.com/threads/68121?p=288306&viewfull=1#post288306
+#
+recipe.hooks.postbuild.4.pattern="{teensytools.path}stdout_redirect" "{build.path}/{build.project_name}.lst" "{compiler.path}{build.toolchain}{build.command.objdump}" -d -S -C "{build.path}/{build.project_name}.elf"
+
+
+## Compute size
+recipe.size.pattern="{compiler.path}{build.toolchain}{build.command.size}" -A "{build.path}/{build.project_name}.elf"
+recipe.size.regex=^(?:\.text|\.text\.progmem|\.text\.itcm|\.data|\.text\.csf)\s+([0-9]+).*
+recipe.size.regex.data=^(?:\.usbdescriptortable|\.dmabuffers|\.usbbuffers|\.data|\.bss|\.noinit|\.text\.itcm|\.text\.itcm\.padding)\s+([0-9]+).*
+recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
+
+## Teensy Ports Discovery
+##  Arduino 1.8.9 requires pathPrefs patch
+##  discovery patters have only limited support for substitution macros,
+##  so we can not use {teensytools.path} or {compiler.path} here
+
+# Teensyduino Installer
+discovery.teensy.pattern="{runtime.hardware.path}/../tools/teensy_ports" -J2
+
+# Arduino Boards Manager
+#discovery.teensy.pattern="{runtime.tools.teensy-tools.path}/teensy_ports" -J2
+#pluggable_discovery.required=teensy:teensy-discovery
+#pluggable_monitor.required.teensy=teensy:teensy-monitor
+
+
+## Teensy Loader
+
+# Teensyduino Installer
+tools.teensyloader.cmd.path={runtime.hardware.path}/../tools
+
+# Arduino Boards Manager
+#tools.teensyloader.cmd.path={runtime.tools.teensy-tools.path}
+
+tools.teensyloader.upload.params.quiet=
+tools.teensyloader.upload.params.verbose=-verbose
+tools.teensyloader.upload.pattern="{cmd.path}/teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={cmd.path}" "-board={build.board}" -reboot "-port={serial.port}" "-portlabel={serial.port.label}" "-portprotocol={serial.port.protocol}"
+
+
+
+
+## Export hex
+recipe.output.tmp_file={build.project_name}.hex
+recipe.output.save_file={build.project_name}.{build.board}.hex
+recipe.hooks.savehex.postsavehex.1.pattern="{teensytools.path}teensy_secure" encrypthex {build.board} "{sketch_path}/{build.project_name}.{build.board}.hex"
+
+# TODO: missing patch in 1.6.6...
+recipe.output.tmp_file2={build.project_name}.elf
+recipe.output.save_file2={build.project_name}.elf
+
+
+# documentation on this file's format
+# https://arduino.github.io/arduino-cli/latest/platform-specification/

--- a/play_sd_wav.cpp
+++ b/play_sd_wav.cpp
@@ -1,0 +1,631 @@
+/* Audio Library for Teensy 3.X
+ * Copyright (c) 2014, Paul Stoffregen, paul@pjrc.com
+ *
+ * Development of this audio library was funded by PJRC.COM, LLC by sales of
+ * Teensy and Audio Adaptor boards.  Please support PJRC's efforts to develop
+ * open source software by purchasing Teensy or other PJRC products.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice, development funding notice, and this permission
+ * notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <Arduino.h>
+#include "play_sd_wav.h"
+#include "spi_interrupt.h"
+
+
+#define STATE_DIRECT_8BIT_MONO		0  // playing mono at native sample rate
+#define STATE_DIRECT_8BIT_STEREO	1  // playing stereo at native sample rate
+#define STATE_DIRECT_16BIT_MONO		2  // playing mono at native sample rate
+#define STATE_DIRECT_16BIT_STEREO	3  // playing stereo at native sample rate
+#define STATE_CONVERT_8BIT_MONO		4  // playing mono, converting sample rate
+#define STATE_CONVERT_8BIT_STEREO	5  // playing stereo, converting sample rate
+#define STATE_CONVERT_16BIT_MONO	6  // playing mono, converting sample rate
+#define STATE_CONVERT_16BIT_STEREO	7  // playing stereo, converting sample rate
+#define STATE_PARSE1			8  // looking for 20 byte ID header
+#define STATE_PARSE2			9  // looking for 16 byte format header
+#define STATE_PARSE3			10 // looking for 8 byte data header
+#define STATE_PARSE4			11 // ignoring unknown chunk after "fmt "
+#define STATE_PARSE5			12 // ignoring unknown chunk before "fmt "
+#define STATE_PAUSED			13
+#define STATE_STOP			14
+
+void AudioPlaySdWavX::begin(void)
+{
+	state = STATE_STOP;
+	state_play = STATE_STOP;
+	data_length = 0;
+	if (block_left) {
+		release(block_left);
+		block_left = NULL;
+	}
+	if (block_right) {
+		release(block_right);
+		block_right = NULL;
+	}
+}
+
+
+bool AudioPlaySdWavX::play(const char *filename)
+{
+	stop();
+	bool irq = false;
+	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
+		NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+		irq = true;
+	}
+#if defined(HAS_KINETIS_SDHC)
+	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStartUsingSPI();
+#else
+	AudioStartUsingSPI();
+#endif
+	wavfile = SD.open(filename);
+	if (!wavfile) {
+#if defined(HAS_KINETIS_SDHC)
+		if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+#else
+		AudioStopUsingSPI();
+#endif
+		if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+		return false;
+	}
+	buffer_length = 0;
+	buffer_offset = 0;
+	state_play = STATE_STOP;
+	data_length = 20;
+	header_offset = 0;
+	state = STATE_PARSE1;
+	if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+	return true;
+}
+
+void AudioPlaySdWavX::stop(void)
+{
+	bool irq = false;
+	if (NVIC_IS_ENABLED(IRQ_SOFTWARE)) {
+		NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
+		irq = true;
+	}
+	if (state != STATE_STOP) {
+		audio_block_t *b1 = block_left;
+		block_left = NULL;
+		audio_block_t *b2 = block_right;
+		block_right = NULL;
+		state = STATE_STOP;
+		if (b1) release(b1);
+		if (b2) release(b2);
+		wavfile.close();
+#if defined(HAS_KINETIS_SDHC)
+		if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+#else
+		AudioStopUsingSPI();
+#endif
+	}
+	if (irq) NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+}
+
+void AudioPlaySdWavX::togglePlayPause(void) {
+	// take no action if wave header is not parsed OR
+	// state is explicitly STATE_STOP
+	if(state_play >= 8 || state == STATE_STOP) return;
+
+	// toggle back and forth between state_play and STATE_PAUSED
+	if(state == state_play) {
+		state = STATE_PAUSED;
+	}
+	else if(state == STATE_PAUSED) {
+		state = state_play;
+	}
+}
+
+void AudioPlaySdWavX::update(void)
+{
+	int32_t n;
+
+	// only update if we're playing and not paused
+	if (state == STATE_STOP || state == STATE_PAUSED) return;
+
+	// allocate the audio blocks to transmit
+	block_left = allocate();
+	if (block_left == NULL) return;
+	if (state < 8 && (state & 1) == 1) {
+		// if we're playing stereo, allocate another
+		// block for the right channel output
+		block_right = allocate();
+		if (block_right == NULL) {
+			release(block_left);
+			return;
+		}
+	} else {
+		// if we're playing mono or just parsing
+		// the WAV file header, no right-side block
+		block_right = NULL;
+	}
+	block_offset = 0;
+
+	//Serial.println("update");
+
+	// is there buffered data?
+	n = buffer_length - buffer_offset;
+	if (n > 0) {
+		// we have buffered data
+		if (consume(n)) return; // it was enough to transmit audio
+	}
+
+	// we only get to this point when buffer[] is empty
+	if (state != STATE_STOP && wavfile.available()) {
+		// we can read more data from the file...
+		readagain:
+		buffer_length = wavfile.read(buffer, sizeof buffer);
+		if (buffer_length == 0) goto end;
+		buffer_offset = 0;
+		bool parsing = (state >= 8);
+		bool txok = consume(buffer_length);
+		if (txok) {
+			if (state != STATE_STOP) return;
+		} else {
+			if (state != STATE_STOP) {
+				if (parsing && state < 8) goto readagain;
+				else goto cleanup;
+			}
+		}
+	}
+end:	// end of file reached or other reason to stop
+	wavfile.close();
+#if defined(HAS_KINETIS_SDHC)
+	if (!(SIM_SCGC3 & SIM_SCGC3_SDHC)) AudioStopUsingSPI();
+#else
+	AudioStopUsingSPI();
+#endif
+	state_play = STATE_STOP;
+	state = STATE_STOP;
+cleanup:
+	if (block_left) {
+		if (block_offset > 0) {
+			for (uint32_t i=block_offset; i < AUDIO_BLOCK_SAMPLES; i++) {
+				block_left->data[i] = 0;
+			}
+			transmit(block_left, 0);
+			if (state < 8 && (state & 1) == 0) {
+				transmit(block_left, 1);
+			}
+		}
+		release(block_left);
+		block_left = NULL;
+	}
+	if (block_right) {
+		if (block_offset > 0) {
+			for (uint32_t i=block_offset; i < AUDIO_BLOCK_SAMPLES; i++) {
+				block_right->data[i] = 0;
+			}
+			transmit(block_right, 1);
+		}
+		release(block_right);
+		block_right = NULL;
+	}
+}
+
+
+// https://ccrma.stanford.edu/courses/422/projects/WaveFormat/
+
+// Consume already buffered data.  Returns true if audio transmitted.
+bool AudioPlaySdWavX::consume(uint32_t size)
+{
+	uint32_t len;
+	uint8_t lsb, msb;
+	const uint8_t *p;
+
+	p = buffer + buffer_offset;
+start:
+	if (size == 0) return false;
+#if 0
+	Serial.print("AudioPlaySdWavX consume, ");
+	Serial.print("size = ");
+	Serial.print(size);
+	Serial.print(", buffer_offset = ");
+	Serial.print(buffer_offset);
+	Serial.print(", data_length = ");
+	Serial.print(data_length);
+	Serial.print(", space = ");
+	Serial.print((AUDIO_BLOCK_SAMPLES - block_offset) * 2);
+	Serial.print(", state = ");
+	Serial.println(state);
+#endif
+	switch (state) {
+	  // parse wav file header, is this really a .wav file?
+	  case STATE_PARSE1:
+		len = data_length;
+		if (size < len) len = size;
+		memcpy((uint8_t *)header + header_offset, p, len);
+		header_offset += len;
+		buffer_offset += len;
+		data_length -= len;
+		if (data_length > 0) return false;
+		// parse the header...
+		if (header[0] == 0x46464952 && header[2] == 0x45564157) {
+			//Serial.println("is wav file");
+			if (header[3] == 0x20746D66) {
+				// "fmt " header
+				if (header[4] < 16) {
+					// WAV "fmt " info must be at least 16 bytes
+					break;
+				}
+				if (header[4] > sizeof(header)) {
+					// if such .wav files exist, increasing the
+					// size of header[] should accomodate them...
+					//Serial.println("WAVEFORMATEXTENSIBLE too long");
+					break;
+				}
+				//Serial.println("header ok");
+				header_offset = 0;
+				state = STATE_PARSE2;
+			} else {
+				// first chuck is something other than "fmt "
+				//Serial.print("skipping \"");
+				//Serial.printf("\" (%08X), ", __builtin_bswap32(header[3]));
+				//Serial.print(header[4]);
+				//Serial.println(" bytes");
+				header_offset = 12;
+				state = STATE_PARSE5;
+			}
+			p += len;
+			size -= len;
+			data_length = header[4];
+			goto start;
+		}
+		//Serial.println("unknown WAV header");
+		break;
+
+	  // check & extract key audio parameters
+	  case STATE_PARSE2:
+		len = data_length;
+		if (size < len) len = size;
+		memcpy((uint8_t *)header + header_offset, p, len);
+		header_offset += len;
+		buffer_offset += len;
+		data_length -= len;
+		if (data_length > 0) return false;
+		if (parse_format()) {
+			//Serial.println("audio format ok");
+			p += len;
+			size -= len;
+			data_length = 8;
+			header_offset = 0;
+			state = STATE_PARSE3;
+			goto start;
+		}
+		//Serial.println("unknown audio format");
+		break;
+
+	  // find the data chunk
+	  case STATE_PARSE3: // 10
+		len = data_length;
+		if (size < len) len = size;
+		memcpy((uint8_t *)header + header_offset, p, len);
+		header_offset += len;
+		buffer_offset += len;
+		data_length -= len;
+		if (data_length > 0) return false;
+		//Serial.print("chunk id = ");
+		//Serial.print(header[0], HEX);
+		//Serial.print(", length = ");
+		//Serial.println(header[1]);
+		p += len;
+		size -= len;
+		data_length = header[1];
+		if (header[0] == 0x61746164) {
+			//Serial.print("wav: found data chunk, len=");
+			//Serial.println(data_length);
+			// TODO: verify offset in file is an even number
+			// as required by WAV format.  abort if odd.  Code
+			// below will depend upon this and fail if not even.
+			leftover_bytes = 0;
+			state = state_play;
+			if (state & 1) {
+				// if we're going to start stereo
+				// better allocate another output block
+				block_right = allocate();
+				if (!block_right) return false;
+			}
+			total_length = data_length;
+		} else {
+			state = STATE_PARSE4;
+		}
+		goto start;
+
+	  // ignore any extra unknown chunks (title & artist info)
+	  case STATE_PARSE4: // 11
+		if (size < data_length) {
+			data_length -= size;
+			buffer_offset += size;
+			return false;
+		}
+		p += data_length;
+		size -= data_length;
+		buffer_offset += data_length;
+		data_length = 8;
+		header_offset = 0;
+		state = STATE_PARSE3;
+		//Serial.println("consumed unknown chunk");
+		goto start;
+
+	  // skip past "junk" data before "fmt " header
+	  case STATE_PARSE5:
+		len = data_length;
+		if (size < len) len = size;
+		buffer_offset += len;
+		data_length -= len;
+		if (data_length > 0) return false;
+		p += len;
+		size -= len;
+		data_length = 8;
+		state = STATE_PARSE1;
+		goto start;
+
+	  // playing mono at native sample rate
+	  case STATE_DIRECT_8BIT_MONO:
+		return false;
+
+	  // playing stereo at native sample rate
+	  case STATE_DIRECT_8BIT_STEREO:
+		return false;
+
+	  // playing mono at native sample rate
+	  case STATE_DIRECT_16BIT_MONO:
+		if (size > data_length) size = data_length;
+		data_length -= size;
+		while (1) {
+			lsb = *p++;
+			msb = *p++;
+			size -= 2;
+			block_left->data[block_offset++] = (msb << 8) | lsb;
+			if (block_offset >= AUDIO_BLOCK_SAMPLES) {
+				transmit(block_left, 0);
+				transmit(block_left, 1);
+				release(block_left);
+				block_left = NULL;
+				data_length += size;
+				buffer_offset = p - buffer;
+				if (block_right) release(block_right);
+				if (data_length == 0) state = STATE_STOP;
+				return true;
+			}
+			if (size == 0) {
+				if (data_length == 0) break;
+				return false;
+			}
+		}
+		//Serial.println("end of file reached");
+		// end of file reached
+		if (block_offset > 0) {
+			// TODO: fill remainder of last block with zero and transmit
+		}
+		state = STATE_STOP;
+		return false;
+
+	  // playing stereo at native sample rate
+	  case STATE_DIRECT_16BIT_STEREO:
+		if (size > data_length) size = data_length;
+		data_length -= size;
+		if (leftover_bytes) {
+			block_left->data[block_offset] = header[0];
+//PAH fix problem with left+right channels being swapped
+			leftover_bytes = 0;
+			goto right16;
+		}
+		while (1) {
+			lsb = *p++;
+			msb = *p++;
+			size -= 2;
+			if (size == 0) {
+				if (data_length == 0) break;
+				header[0] = (msb << 8) | lsb;
+				leftover_bytes = 2;
+				return false;
+			}
+			block_left->data[block_offset] = (msb << 8) | lsb;
+			right16:
+			lsb = *p++;
+			msb = *p++;
+			size -= 2;
+			block_right->data[block_offset++] = (msb << 8) | lsb;
+			if (block_offset >= AUDIO_BLOCK_SAMPLES) {
+				transmit(block_left, 0);
+				release(block_left);
+				block_left = NULL;
+				transmit(block_right, 1);
+				release(block_right);
+				block_right = NULL;
+				data_length += size;
+				buffer_offset = p - buffer;
+				if (data_length == 0) state = STATE_STOP;
+				return true;
+			}
+			if (size == 0) {
+				if (data_length == 0) break;
+				leftover_bytes = 0;
+				return false;
+			}
+		}
+		// end of file reached
+		if (block_offset > 0) {
+			// TODO: fill remainder of last block with zero and transmit
+		}
+		state = STATE_STOP;
+		return false;
+
+	  // playing mono, converting sample rate
+	  case STATE_CONVERT_8BIT_MONO :
+		return false;
+
+	  // playing stereo, converting sample rate
+	  case STATE_CONVERT_8BIT_STEREO:
+		return false;
+
+	  // playing mono, converting sample rate
+	  case STATE_CONVERT_16BIT_MONO:
+		return false;
+
+	  // playing stereo, converting sample rate
+	  case STATE_CONVERT_16BIT_STEREO:
+		return false;
+
+	  // ignore any extra data after playing
+	  // or anything following any error
+	  case STATE_STOP:
+		return false;
+
+	  // this is not supposed to happen!
+	  //default:
+		//Serial.println("AudioPlaySdWavX, unknown state");
+	}
+	state_play = STATE_STOP;
+	state = STATE_STOP;
+	return false;
+}
+
+
+/*
+00000000  52494646 66EA6903 57415645 666D7420  RIFFf.i.WAVEfmt 
+00000010  10000000 01000200 44AC0000 10B10200  ........D.......
+00000020  04001000 4C495354 3A000000 494E464F  ....LIST:...INFO
+00000030  494E414D 14000000 49205761 6E742054  INAM....I Want T
+00000040  6F20436F 6D65204F 76657200 49415254  o Come Over.IART
+00000050  12000000 4D656C69 73736120 45746865  ....Melissa Ethe
+00000060  72696467 65006461 746100EA 69030100  ridge.data..i...
+00000070  FEFF0300 FCFF0400 FDFF0200 0000FEFF  ................
+00000080  0300FDFF 0200FFFF 00000100 FEFF0300  ................
+00000090  FDFF0300 FDFF0200 FFFF0100 0000FFFF  ................
+*/
+
+
+
+
+
+// SD library on Teensy3 at 96 MHz
+//  256 byte chunks, speed is 443272 bytes/sec
+//  512 byte chunks, speed is 468023 bytes/sec
+
+#define B2M_44100 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT) // 97352592
+#define B2M_22050 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT * 2.0)
+#define B2M_11025 (uint32_t)((double)4294967296000.0 / AUDIO_SAMPLE_RATE_EXACT * 4.0)
+
+bool AudioPlaySdWavX::parse_format(void)
+{
+	uint8_t num = 0;
+	uint16_t format;
+	uint16_t channels;
+	uint32_t rate, b2m;
+	uint16_t bits;
+
+	format = header[0];
+	//Serial.print("  format = ");
+	//Serial.println(format);
+	if (format != 1) return false;
+
+	rate = header[1];
+	//Serial.print("  rate = ");
+	//Serial.println(rate);
+	if (rate == 44100) {
+		b2m = B2M_44100;
+	} else if (rate == 22050) {
+		b2m = B2M_22050;
+		num |= 4;
+	} else if (rate == 11025) {
+		b2m = B2M_11025;
+		num |= 4;
+	} else {
+		return false;
+	}
+
+	channels = header[0] >> 16;
+	//Serial.print("  channels = ");
+	//Serial.println(channels);
+	if (channels == 1) {
+	} else if (channels == 2) {
+		b2m >>= 1;
+		num |= 1;
+	} else {
+		return false;
+	}
+
+	bits = header[3] >> 16;
+	//Serial.print("  bits = ");
+	//Serial.println(bits);
+	if (bits == 8) {
+	} else if (bits == 16) {
+		b2m >>= 1;
+		num |= 2;
+	} else {
+		return false;
+	}
+
+	bytes2millis = b2m;
+	//Serial.print("  bytes2millis = ");
+	//Serial.println(b2m);
+
+	// we're not checking the byte rate and block align fields
+	// if they're not the expected values, all we could do is
+	// return false.  Do any real wav files have unexpected
+	// values in these other fields?
+	state_play = num;
+	return true;
+}
+
+
+bool AudioPlaySdWavX::isPlaying(void)
+{
+	uint8_t s = *(volatile uint8_t *)&state;
+	return (s < 8);
+}
+
+
+bool AudioPlaySdWavX::isPaused(void)
+{
+	uint8_t s = *(volatile uint8_t *)&state;
+	return (s == STATE_PAUSED);
+}
+
+
+bool AudioPlaySdWavX::isStopped(void)
+{
+	uint8_t s = *(volatile uint8_t *)&state;
+	return (s == STATE_STOP);
+}
+
+
+uint32_t AudioPlaySdWavX::positionMillis(void)
+{
+	uint8_t s = *(volatile uint8_t *)&state;
+	if (s >= 8 && s != STATE_PAUSED) return 0;
+	uint32_t tlength = *(volatile uint32_t *)&total_length;
+	uint32_t dlength = *(volatile uint32_t *)&data_length;
+	uint32_t offset = tlength - dlength;
+	uint32_t b2m = *(volatile uint32_t *)&bytes2millis;
+	return ((uint64_t)offset * b2m) >> 32;
+}
+
+
+uint32_t AudioPlaySdWavX::lengthMillis(void)
+{
+	uint8_t s = *(volatile uint8_t *)&state;
+	if (s >= 8 && s != STATE_PAUSED) return 0;
+	uint32_t tlength = *(volatile uint32_t *)&total_length;
+	uint32_t b2m = *(volatile uint32_t *)&bytes2millis;
+	return ((uint64_t)tlength * b2m) >> 32;
+}

--- a/play_sd_wav.h
+++ b/play_sd_wav.h
@@ -1,0 +1,68 @@
+/* Audio Library for Teensy 3.X
+ * Copyright (c) 2014, Paul Stoffregen, paul@pjrc.com
+ *
+ * Development of this audio library was funded by PJRC.COM, LLC by sales of
+ * Teensy and Audio Adaptor boards.  Please support PJRC's efforts to develop
+ * open source software by purchasing Teensy or other PJRC products.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice, development funding notice, and this permission
+ * notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef play_sd_wavx_h_
+#define play_sd_wavx_h_
+
+#include "Arduino.h"
+#include "AudioStream.h"
+#include "SD.h"
+
+class AudioPlaySdWavX : public AudioStream
+{
+public:
+	AudioPlaySdWavX(void) : AudioStream(0, NULL), block_left(NULL), block_right(NULL) { begin(); }
+	void begin(void);
+	bool play(const char *filename);
+	void togglePlayPause(void);
+	void stop(void);
+	bool isPlaying(void);
+	bool isPaused(void);
+	bool isStopped(void);
+	uint32_t positionMillis(void);
+	uint32_t lengthMillis(void);
+	virtual void update(void);
+private:
+	File wavfile;
+	bool consume(uint32_t size);
+	bool parse_format(void);
+	uint32_t header[10];		// temporary storage of wav header data
+	uint32_t data_length;		// number of bytes remaining in current section
+	uint32_t total_length;		// number of audio data bytes in file
+	uint32_t bytes2millis;
+	audio_block_t *block_left;
+	audio_block_t *block_right;
+	uint16_t block_offset;		// how much data is in block_left & block_right
+	uint8_t buffer[AUDIO_BLOCK_SAMPLES*sizeof(int16_t)*2];		// buffer two blocks of data
+	uint16_t buffer_offset;		// where we're at consuming "buffer"
+	uint16_t buffer_length;		// how much data is in "buffer" 
+	uint8_t header_offset;		// number of bytes in header[]
+	uint8_t state;
+	uint8_t state_play;
+	uint8_t leftover_bytes;
+};
+
+#endif


### PR DESCRIPTION
[Reports on this forum thread](https://forum.pjrc.com/threads/70553-Teensy-4-0-based-Audio-Guestbook) suggest significant issues with recording, resulting in glitches and dropouts. There appear to several issues, depending on whether the SD slot in use is the built-in one on a Teensy 4.1, or on the audio adaptor; whether MTP is enabled; and how often the audio updates occur.

This pull request addresses these issues, and additionally fixes a problem with wrong chunk lengths in the WAV file header, and adds code to make it fairly easy to determine whether SD card writes are taking too long. 