### PR TITLE
Recognize hook on record beep

### DIFF
--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -378,11 +378,16 @@ void playAllRecordings() {
       Serial.println(entry.name());
       // Play a short beep before each message
       waveform1.amplitude(beep_volume);
-      wait(750);
-      waveform1.amplitude(0);
-      // Play the file
-      playWav1.play(entry.name());
-      mode = Mode::Playing; print_mode();
+      if (wait(750)) {
+        waveform1.amplitude(0);
+        // Play the file
+        playWav1.play(entry.name());
+        mode = Mode::Playing; print_mode();
+      } else {
+        waveform1.amplitude(0);
+        mode = Mode::Ready; print_mode();
+        return;
+      }
     }
     entry.close();
 

--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -180,28 +180,32 @@ void loop() {
 
     case Mode::Prompting:
       // Wait a second for users to put the handset to their ear
-      wait(1000);
-      // Play the greeting inviting them to record their message
-      playWav1.play("greeting.wav");    
-      // Wait until the  message has finished playing
-//      while (playWav1.isPlaying()) {
-      while (!playWav1.isStopped()) {
-        // Check whether the handset is replaced
-        buttonRecord.update();
-        buttonPlay.update();
-        // Handset is replaced
-        if(buttonRecord.risingEdge()) {
-          playWav1.stop();
-          mode = Mode::Ready; print_mode();
-          return;
+      if (wait(1000)) {
+        // Play the greeting inviting them to record their message
+        playWav1.play("greeting.wav");
+        // Wait until the  message has finished playing
+        // while (playWav1.isPlaying()) {
+        while (!playWav1.isStopped()) {
+          // Check whether the handset is replaced
+          buttonRecord.update();
+          buttonPlay.update();
+          // Handset is replaced
+          if (buttonRecord.risingEdge()) {
+            playWav1.stop();
+            mode = Mode::Ready; print_mode();
+            return;
+          }
+          if (buttonPlay.fallingEdge()) {
+            playWav1.stop();
+            //playAllRecordings();
+            playLastRecording();
+            return;
+          }
+
         }
-        if(buttonPlay.fallingEdge()) {
-          playWav1.stop();
-          //playAllRecordings();
-          playLastRecording();
-          return;
-        }
-        
+      } else {
+        mode = Mode::Ready; print_mode();
+        return;
       }
       // Debug message
       Serial.println("Starting Recording");

--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -207,10 +207,16 @@ void loop() {
       Serial.println("Starting Recording");
       // Play the tone sound effect
       waveform1.begin(beep_volume, 440, WAVEFORM_SINE);
-      wait(1250);
-      waveform1.amplitude(0);
+      if (wait(1250)) {
+        waveform1.amplitude(0);
       // Start the recording function
-      startRecording();
+          startRecording();
+      } else {
+        waveform1.amplitude(0);
+        mode = Mode::Ready; print_mode();
+        return;
+      }
+      
       break;
 
     case Mode::Recording:

--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -447,17 +447,21 @@ void dateTime(uint16_t* date, uint16_t* time, uint8_t* ms10) {
 
 // Non-blocking delay, which pauses execution of main program logic,
 // but while still listening for input 
-void wait(unsigned int milliseconds) {
+boolean wait(unsigned int milliseconds) {
   elapsedMillis msec=0;
 
   while (msec <= milliseconds) {
     buttonRecord.update();
     buttonPlay.update();
-    if (buttonRecord.fallingEdge()) Serial.println("Button (pin 0) Press");
+    if (buttonRecord.fallingEdge()) {
+      Serial.println("Button (pin 0) Press");
+      return false;
+    }
     if (buttonPlay.fallingEdge()) Serial.println("Button (pin 1) Press");
     if (buttonRecord.risingEdge()) Serial.println("Button (pin 0) Release");
     if (buttonPlay.risingEdge()) Serial.println("Button (pin 1) Release");
   }
+  return true;
 }
 
 

--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -447,6 +447,7 @@ void dateTime(uint16_t* date, uint16_t* time, uint8_t* ms10) {
 
 // Non-blocking delay, which pauses execution of main program logic,
 // but while still listening for input 
+// Returns false on hook interrupt and true, if no interrupt.
 boolean wait(unsigned int milliseconds) {
   elapsedMillis msec=0;
 


### PR DESCRIPTION
After building the audio-guestbook and using it on a wedding for the first time, I came across an issue: If you put the hook back, while the _beep_ before the recording is played, the hook press is not recognized. The problem is: while in the `wait()`-function, button presses are recognized, but not communicated to outside of `wait()`.
I found some issues for this problem, but was not convinced of the solutions (max recording time 120seconds), so I made this one.

I made `wait()` return `boolean` instead of `void`. If the `recordButton` is pressed, the hook is back on it (raising/falling edge still need to be checked for your specific telephone). If the hook is back on, the `wait()`-function is interrupted and returns `false`. If `wait()` was able to run through, it returns `true`.
Before starting the record, it's checked if `wait()` is running through without interrupts (returning `true`). If so, start recording. If `wait()` is interrupted and returns `false`, immediately stop the _beep_ and get into mode `Ready`.