### PR TITLE
update audio-guestbook.ino

### DIFF
--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -29,518 +29,340 @@
 #include <TimeLib.h>
 #include <MTP_Teensy.h>
 #include "play_sd_wav.h" // local copy with fixes
+#include <elapsedMillis.h>
 
 // DEFINES
-// Define pins used by Teensy Audio Shield
 #define SDCARD_CS_PIN    10
 #define SDCARD_MOSI_PIN  7
 #define SDCARD_SCK_PIN   14
-// And those used for inputs
 #define HOOK_PIN 0
 #define PLAYBACK_BUTTON_PIN 1
-
-#define noINSTRUMENT_SD_WRITE
+#define RECORDING_TIMEOUT 600000  // 10 minutes in milliseconds
 
 // GLOBALS
-// Audio initialisation code can be generated using the GUI interface at https://www.pjrc.com/teensy/gui/
-// Inputs
-AudioSynthWaveform          waveform1; // To create the "beep" sfx
-AudioInputI2S               i2s2; // I2S input from microphone on audio shield
-AudioPlaySdWavX              playWav1; // Play 44.1kHz 16-bit PCM greeting WAV file
-AudioRecordQueue            queue1; // Creating an audio buffer in memory before saving to SD
-AudioMixer4                 mixer; // Allows merging several inputs to same output
-AudioOutputI2S              i2s1; // I2S interface to Speaker/Line Out on Audio shield
-AudioConnection patchCord1(waveform1, 0, mixer, 0); // wave to mixer 
-AudioConnection patchCord3(playWav1, 0, mixer, 1); // wav file playback mixer
-AudioConnection patchCord4(mixer, 0, i2s1, 0); // mixer output to speaker (L)
-AudioConnection patchCord6(mixer, 0, i2s1, 1); // mixer output to speaker (R)
-AudioConnection patchCord5(i2s2, 0, queue1, 0); // mic input to queue (L)
-AudioControlSGTL5000      sgtl5000_1;
+AudioSynthWaveform waveform1;
+AudioInputI2S i2s2;
+AudioPlaySdWav playWav1;
+AudioRecordQueue queue1;
+AudioMixer4 mixer;
+AudioOutputI2S i2s1;
+AudioControlSGTL5000 sgtl5000_1;
+AudioConnection patchCord1(waveform1, 0, mixer, 0);
+AudioConnection patchCord3(playWav1, 0, mixer, 1);
+AudioConnection patchCord4(mixer, 0, i2s1, 0);
+AudioConnection patchCord6(mixer, 0, i2s1, 1);
+AudioConnection patchCord5(i2s2, 0, queue1, 0);
 
-// Filename to save audio recording on SD card
 char filename[15];
-// The file object itself
 File frec;
 
-// Use long 40ms debounce time on both switches
-Bounce buttonRecord = Bounce(HOOK_PIN, 40);
+Bounce buttonRecord = Bounce(HOOK_PIN, 40);  // Increased debounce time to original value
 Bounce buttonPlay = Bounce(PLAYBACK_BUTTON_PIN, 40);
 
-// Keep track of current state of the device
 enum Mode {Initialising, Ready, Prompting, Recording, Playing};
 Mode mode = Mode::Initialising;
 
-float beep_volume = 0.04f; // not too loud :-)
+float beep_volume = 0.04f;
+uint32_t MTPcheckInterval;
 
-uint32_t MTPcheckInterval; // default value of device check interval [ms]
+elapsedMillis recordingTime; // Timer to limit recording duration
 
-// variables for writing to WAV file
-unsigned long ChunkSize = 0L;
-unsigned long Subchunk1Size = 16;
-unsigned int AudioFormat = 1;
-unsigned int numChannels = 1;
-unsigned long sampleRate = 44100;
-unsigned int bitsPerSample = 16;
-unsigned long byteRate = sampleRate*numChannels*(bitsPerSample/8);// samplerate x channels x (bitspersample / 8)
-unsigned int blockAlign = numChannels*bitsPerSample/8;
-unsigned long Subchunk2Size = 0L;
+// WAV file parameters
 unsigned long recByteSaved = 0L;
-unsigned long NumSamples = 0L;
-byte byte1, byte2, byte3, byte4;
 
+time_t getTeensy3Time() {
+  return Teensy3Clock.get();
+}
+
+void dateTime(uint16_t* date, uint16_t* time, uint8_t* ms10) {
+  *date = FS_DATE(year(), month(), day());
+  *time = FS_TIME(hour(), minute(), second());
+  *ms10 = second() & 1 ? 100 : 0;
+}
 
 void setup() {
-
   Serial.begin(9600);
-  while (!Serial && millis() < 5000) {
-    // wait for serial port to connect.
-  }
+  while (!Serial && millis() < 5000) {}
   Serial.println("Serial set up correctly");
-  Serial.printf("Audio block set to %d samples\n",AUDIO_BLOCK_SAMPLES);
-  print_mode();
-  // Configure the input pins
+
   pinMode(HOOK_PIN, INPUT_PULLUP);
   pinMode(PLAYBACK_BUTTON_PIN, INPUT_PULLUP);
 
-  // Audio connections require memory, and the record queue
-  // uses this memory to buffer incoming audio.
-  AudioMemory(60);
-
-  // Enable the audio shield, select input, and enable output
+  AudioMemory(120);  // Increased memory to handle more data
   sgtl5000_1.enable();
-  // Define which input on the audio shield to use (AUDIO_INPUT_LINEIN / AUDIO_INPUT_MIC)
   sgtl5000_1.inputSelect(AUDIO_INPUT_MIC);
-  //sgtl5000_1.adcHighPassFilterDisable(); //
-  sgtl5000_1.volume(0.95);
-
+  sgtl5000_1.volume(0.85); // Further reduce volume to avoid clipping
+  sgtl5000_1.micGain(2);  // Lower mic gain to reduce static and warbling
   mixer.gain(0, 1.0f);
   mixer.gain(1, 1.0f);
-
-  // Play a beep to indicate system is online
+  
   waveform1.begin(beep_volume, 440, WAVEFORM_SINE);
   wait(1000);
   waveform1.amplitude(0);
   delay(1000);
 
-  // Initialize the SD card
   SPI.setMOSI(SDCARD_MOSI_PIN);
   SPI.setSCK(SDCARD_SCK_PIN);
-  if (!(SD.begin(SDCARD_CS_PIN))) 
-  {
-    // stop here if no SD card, but print a message
+  if (!(SD.begin(SDCARD_CS_PIN))) {
     while (1) {
       Serial.println("Unable to access the SD card");
       delay(500);
     }
+  } else {
+    Serial.println("SD card correctly initialized");
   }
-    else Serial.println("SD card correctly initialized");
 
+  MTP.begin();
+  MTP.addFilesystem(SD, "Rolfo Audio guestbook");
+  MTPcheckInterval = MTP.storage()->get_DeltaDeviceCheckTimeMS();
 
-  // mandatory to begin the MTP session.
-    MTP.begin();
-
-  // Add SD Card
-//    MTP.addFilesystem(SD, "SD Card");
-    MTP.addFilesystem(SD, "Kais Audio guestbook"); // choose a nice name for the SD card volume to appear in your file explorer
-    Serial.println("Added SD card via MTP");
-    MTPcheckInterval = MTP.storage()->get_DeltaDeviceCheckTimeMS();
-    
-    // Value in dB
-//  sgtl5000_1.micGain(15);
-  sgtl5000_1.micGain(5); // much lower gain is required for the AOM5024 electret capsule
-
-  // Synchronise the Time object used in the program code with the RTC time provider.
-  // See https://github.com/PaulStoffregen/Time
   setSyncProvider(getTeensy3Time);
-  
-  // Define a callback that will assign the correct datetime for any file system operations
-  // (i.e. saving a new audio recording onto the SD card)
   FsDateTime::setCallback(dateTime);
 
-  mode = Mode::Ready; print_mode();
+  mode = Mode::Ready; 
+  print_mode();
 }
 
 void loop() {
-  // First, read the buttons
   buttonRecord.update();
   buttonPlay.update();
 
   switch(mode){
     case Mode::Ready:
-      // Falling edge occurs when the handset is lifted --> 611 telephone
       if (buttonRecord.fallingEdge()) {
         Serial.println("Handset lifted");
-        mode = Mode::Prompting; print_mode();
-      }
-      else if(buttonPlay.fallingEdge()) {
-        //playAllRecordings();
+        mode = Mode::Prompting;
+        print_mode();
+      } else if(buttonPlay.fallingEdge()) {
         playLastRecording();
       }
       break;
 
     case Mode::Prompting:
-      // Wait a second for users to put the handset to their ear
       wait(1000);
-      // Play the greeting inviting them to record their message
-      playWav1.play("greeting.wav");    
-      // Wait until the  message has finished playing
-//      while (playWav1.isPlaying()) {
+      playWav1.play("greeting.wav");
       while (!playWav1.isStopped()) {
-        // Check whether the handset is replaced
         buttonRecord.update();
         buttonPlay.update();
-        // Handset is replaced
         if(buttonRecord.risingEdge()) {
           playWav1.stop();
-          mode = Mode::Ready; print_mode();
+          mode = Mode::Ready;
+          print_mode();
           return;
         }
         if(buttonPlay.fallingEdge()) {
           playWav1.stop();
-          //playAllRecordings();
           playLastRecording();
           return;
         }
-        
       }
-      // Debug message
       Serial.println("Starting Recording");
-      // Play the tone sound effect
       waveform1.begin(beep_volume, 440, WAVEFORM_SINE);
       wait(1250);
       waveform1.amplitude(0);
-      // Start the recording function
       startRecording();
       break;
 
     case Mode::Recording:
-      // Handset is replaced
       if(buttonRecord.risingEdge()){
-        // Debug log
         Serial.println("Stopping Recording");
-        // Stop recording
         stopRecording();
-        // Play audio tone to confirm recording has ended
         end_Beep();
-      }
-      else {
+      } else {
         continueRecording();
       }
       break;
 
-    case Mode::Playing: // to make compiler happy
-      break;  
+    case Mode::Playing: 
+      if(playWav1.isStopped()) {
+        Serial.println("Playback finished. Returning to Ready mode.");
+        mode = Mode::Ready;
+        print_mode();
+      }
+      break;
 
-    case Mode::Initialising: // to make compiler happy
-      break;  
-  }   
-  
-  MTP.loop();  // This is mandatory to be placed in the loop code.
+    case Mode::Initialising: 
+      break;
+  }
+
+  MTP.loop();
 }
 
-void setMTPdeviceChecks(bool nable)
-{
-  if (nable)
-  {
-    MTP.storage()->set_DeltaDeviceCheckTimeMS(MTPcheckInterval);
-    Serial.print("En");
-  }
-  else
-  {
-    MTP.storage()->set_DeltaDeviceCheckTimeMS((uint32_t) -1);
-    Serial.print("Dis");
-  }
-  Serial.println("abled MTP storage device checks");
+void setMTPdeviceChecks(bool enable) {
+  MTP.storage()->set_DeltaDeviceCheckTimeMS(enable ? MTPcheckInterval : 60000);
 }
-  
-
-#if defined(INSTRUMENT_SD_WRITE)
-static uint32_t worstSDwrite, printNext;
-#endif // defined(INSTRUMENT_SD_WRITE)
 
 void startRecording() {
-  setMTPdeviceChecks(false); // disable MTP device checks while recording
-#if defined(INSTRUMENT_SD_WRITE)
-  worstSDwrite = 0;
-  printNext = 0;
-#endif // defined(INSTRUMENT_SD_WRITE)
-  // Find the first available file number
-//  for (uint8_t i=0; i<9999; i++) { // BUGFIX uint8_t overflows if it reaches 255  
-  for (uint16_t i=0; i<9999; i++) {   
-    // Format the counter as a five-digit number with leading zeroes, followed by file extension
+  setMTPdeviceChecks(false);
+  recordingTime = 0; // Start the recording timer
+
+  for (uint16_t i=0; i<9999; i++) {
     snprintf(filename, 11, " %05d.wav", i);
-    // Create if does not exist, do not open existing, write, sync after write
     if (!SD.exists(filename)) {
       break;
     }
   }
   frec = SD.open(filename, FILE_WRITE);
-  Serial.println("Opened file !");
+  Serial.println("Opened file!");
+
   if(frec) {
     Serial.print("Recording to ");
     Serial.println(filename);
     queue1.begin();
-    mode = Mode::Recording; print_mode();
+    mode = Mode::Recording;
+    print_mode();
     recByteSaved = 0L;
-  }
-  else {
+  } else {
     Serial.println("Couldn't open file to record!");
   }
 }
 
 void continueRecording() {
-#if defined(INSTRUMENT_SD_WRITE)
-  uint32_t started = micros();
-#endif // defined(INSTRUMENT_SD_WRITE)
-#define NBLOX 16  
-  // Check if there is data in the queue
-  if (queue1.available() >= NBLOX) {
-    byte buffer[NBLOX*AUDIO_BLOCK_SAMPLES*sizeof(int16_t)];
-    // Fetch 2 blocks from the audio library and copy
-    // into a 512 byte buffer.  The Arduino SD library
-    // is most efficient when full 512 byte sector size
-    // writes are used.
-    for (int i=0;i<NBLOX;i++)
-    {
-      memcpy(buffer+i*AUDIO_BLOCK_SAMPLES*sizeof(int16_t), queue1.readBuffer(), AUDIO_BLOCK_SAMPLES*sizeof(int16_t));
+  if (recordingTime > RECORDING_TIMEOUT) {  // Check for timeout (10 minutes)
+    Serial.println("Recording timeout reached. Stopping recording.");
+    stopRecording();
+    end_Beep();
+    return;
+  }
+
+  if (queue1.available() >= 32) {  // Increase the number of available blocks before writing
+    byte buffer[32 * AUDIO_BLOCK_SAMPLES * sizeof(int16_t)];
+    for (int i=0; i<32; i++) {
+      memcpy(buffer + i * AUDIO_BLOCK_SAMPLES * sizeof(int16_t), queue1.readBuffer(), AUDIO_BLOCK_SAMPLES * sizeof(int16_t));
       queue1.freeBuffer();
     }
-    // Write all 512 bytes to the SD card
     frec.write(buffer, sizeof buffer);
     recByteSaved += sizeof buffer;
   }
-  
-#if defined(INSTRUMENT_SD_WRITE)
-  started = micros() - started;
-  if (started > worstSDwrite)
-    worstSDwrite = started;
-
-  if (millis() >= printNext)
-  {
-    Serial.printf("Worst write took %luus\n",worstSDwrite);
-    worstSDwrite = 0;
-    printNext = millis()+250;
-  }
-#endif // defined(INSTRUMENT_SD_WRITE)
 }
 
 void stopRecording() {
-  // Stop adding any new data to the queue
   queue1.end();
-  // Flush all existing remaining data from the queue
   while (queue1.available() > 0) {
-    // Save to open file
-    frec.write((byte*)queue1.readBuffer(), AUDIO_BLOCK_SAMPLES*sizeof(int16_t));
+    frec.write((byte*)queue1.readBuffer(), AUDIO_BLOCK_SAMPLES * sizeof(int16_t));
     queue1.freeBuffer();
-    recByteSaved += AUDIO_BLOCK_SAMPLES*sizeof(int16_t);
+    recByteSaved += AUDIO_BLOCK_SAMPLES * sizeof(int16_t);
   }
   writeOutHeader();
-  // Close the file
   frec.close();
-  Serial.println("Closed file");
-  mode = Mode::Ready; print_mode();
-  setMTPdeviceChecks(true); // enable MTP device checks, recording is finished
-}
-
-
-void playAllRecordings() {
-  // Recording files are saved in the root directory
-  File dir = SD.open("/");
-  
-  while (true) {
-    File entry =  dir.openNextFile();
-    if (strstr(entry.name(), "greeting"))
-    {
-       entry =  dir.openNextFile();
-    }
-    if (!entry) {
-      // no more files
-      entry.close();
-      end_Beep();
-      break;
-    }
-    //int8_t len = strlen(entry.name()) - 4;
-//    if (strstr(strlwr(entry.name() + (len - 4)), ".raw")) {
-//    if (strstr(strlwr(entry.name() + (len - 4)), ".wav")) {
-    // the lines above throw a warning, so I replace them with this (which is also easier to read):
-    if (strstr(entry.name(), ".wav") || strstr(entry.name(), ".WAV")) {
-      Serial.print("Now playing ");
-      Serial.println(entry.name());
-      // Play a short beep before each message
-      waveform1.amplitude(beep_volume);
-      wait(750);
-      waveform1.amplitude(0);
-      // Play the file
-      playWav1.play(entry.name());
-      mode = Mode::Playing; print_mode();
-    }
-    entry.close();
-
-//    while (playWav1.isPlaying()) { // strangely enough, this works for playRaw, but it does not work properly for playWav
-    while (!playWav1.isStopped()) { // this works for playWav
-      buttonPlay.update();
-      buttonRecord.update();
-      // Button is pressed again
-//      if(buttonPlay.risingEdge() || buttonRecord.risingEdge()) { // FIX
-      if(buttonPlay.fallingEdge() || buttonRecord.risingEdge()) { 
-        playWav1.stop();
-        mode = Mode::Ready; print_mode();
-        return;
-      }   
-    }
-  }
-  // All files have been played
-  mode = Mode::Ready; print_mode();
+  mode = Mode::Ready;
+  print_mode();
+  setMTPdeviceChecks(true);
 }
 
 void playLastRecording() {
-  // Find the first available file number
   uint16_t idx = 0; 
   for (uint16_t i=0; i<9999; i++) {
-    // Format the counter as a five-digit number with leading zeroes, followed by file extension
     snprintf(filename, 11, " %05d.wav", i);
-    // check, if file with index i exists
     if (!SD.exists(filename)) {
-     idx = i - 1;
-     break;
-      }
-  }
-      // now play file with index idx == last recorded file
-      snprintf(filename, 11, " %05d.wav", idx);
-      Serial.println(filename);
-      playWav1.play(filename);
-      mode = Mode::Playing; print_mode();
-      while (!playWav1.isStopped()) { // this works for playWav
-      buttonPlay.update();
-      buttonRecord.update();
-      // Button is pressed again
-//      if(buttonPlay.risingEdge() || buttonRecord.risingEdge()) { // FIX
-      if(buttonPlay.fallingEdge() || buttonRecord.risingEdge()) {
-        playWav1.stop();
-        mode = Mode::Ready; print_mode();
-        return;
-      }   
+      idx = i - 1;
+      break;
     }
-      // file has been played
-  mode = Mode::Ready; print_mode();  
-  end_Beep();
+  }
+  snprintf(filename, 11, " %05d.wav", idx);
+  Serial.println(filename);
+  playWav1.play(filename);
+  mode = Mode::Playing;
+  print_mode();
 }
 
+void writeOutHeader() {
+  unsigned long Subchunk2Size = recByteSaved - 42;
+  unsigned long ChunkSize = Subchunk2Size + 34;
 
-// Retrieve the current time from Teensy built-in RTC
-time_t getTeensy3Time(){
-  return Teensy3Clock.get();
+  frec.seek(0);  // Move back to the start of the file
+
+  // Write "RIFF" chunk descriptor
+  frec.write("RIFF");
+
+  // Write chunk size
+  frec.write(ChunkSize & 0xFF);
+  frec.write((ChunkSize >> 8) & 0xFF);
+  frec.write((ChunkSize >> 16) & 0xFF);
+  frec.write((ChunkSize >> 24) & 0xFF);
+
+  // Write file format
+  frec.write("WAVE");
+
+  // Write "fmt " sub-chunk
+  frec.write("fmt ");
+
+  // Subchunk1Size (16 for PCM)
+  frec.write(16 & 0xFF);
+  frec.write((16 >> 8) & 0xFF);
+  frec.write((16 >> 16) & 0xFF);
+  frec.write((16 >> 24) & 0xFF);
+
+  // AudioFormat (1 for PCM)
+  frec.write(1 & 0xFF);
+  frec.write((1 >> 8) & 0xFF);
+
+  // NumChannels (1 for mono)
+  frec.write(1 & 0xFF);
+  frec.write((1 >> 8) & 0xFF);
+
+  // SampleRate (44100 Hz)
+  frec.write(44100 & 0xFF);
+  frec.write((44100 >> 8) & 0xFF);
+  frec.write((44100 >> 16) & 0xFF);
+  frec.write((44100 >> 24) & 0xFF);
+
+  // ByteRate (SampleRate * NumChannels * BitsPerSample/8)
+  unsigned long byteRate = 44100 * 1 * 16 / 8;
+  frec.write(byteRate & 0xFF);
+  frec.write((byteRate >> 8) & 0xFF);
+  frec.write((byteRate >> 16) & 0xFF);
+  frec.write((byteRate >> 24) & 0xFF);
+
+  // BlockAlign (NumChannels * BitsPerSample/8)
+  unsigned int blockAlign = 1 * 16 / 8;
+  frec.write(blockAlign & 0xFF);
+  frec.write((blockAlign >> 8) & 0xFF);
+
+  // BitsPerSample (16 bits)
+  frec.write(16 & 0xFF);
+  frec.write((16 >> 8) & 0xFF);
+
+  // Write "data" sub-chunk
+  frec.write("data");
+
+  // Subchunk2Size (NumSamples * NumChannels * BitsPerSample/8)
+  frec.write(Subchunk2Size & 0xFF);
+  frec.write((Subchunk2Size >> 8) & 0xFF);
+  frec.write((Subchunk2Size >> 16) & 0xFF);
+  frec.write((Subchunk2Size >> 24) & 0xFF);
+
+  frec.close();  // Close the file after writing the header
+  Serial.println("Header written");
 }
 
-// Callback to assign timestamps for file system operations
-void dateTime(uint16_t* date, uint16_t* time, uint8_t* ms10) {
-
-  // Return date using FS_DATE macro to format fields.
-  *date = FS_DATE(year(), month(), day());
-
-  // Return time using FS_TIME macro to format fields.
-  *time = FS_TIME(hour(), minute(), second());
-
-  // Return low time bits in units of 10 ms.
-  *ms10 = second() & 1 ? 100 : 0;
+void end_Beep() {
+  for (int i = 0; i < 4; i++) {
+    waveform1.frequency(523.25);
+    waveform1.amplitude(beep_volume);
+    wait(250);
+    waveform1.amplitude(0);
+    wait(250);
+  }
 }
 
-// Non-blocking delay, which pauses execution of main program logic,
-// but while still listening for input 
 void wait(unsigned int milliseconds) {
-  elapsedMillis msec=0;
-
+  elapsedMillis msec = 0;
   while (msec <= milliseconds) {
     buttonRecord.update();
     buttonPlay.update();
-    if (buttonRecord.fallingEdge()) Serial.println("Button (pin 0) Press");
-    if (buttonPlay.fallingEdge()) Serial.println("Button (pin 1) Press");
-    if (buttonRecord.risingEdge()) Serial.println("Button (pin 0) Release");
-    if (buttonPlay.risingEdge()) Serial.println("Button (pin 1) Release");
   }
 }
 
-
-void writeOutHeader() { // update WAV header with final filesize/datasize
-
-//  NumSamples = (recByteSaved*8)/bitsPerSample/numChannels;
-//  Subchunk2Size = NumSamples*numChannels*bitsPerSample/8; // number of samples x number of channels x number of bytes per sample
-  Subchunk2Size = recByteSaved - 42; // because we didn't make space for the header to start with! Lose 21 samples...
-  ChunkSize = Subchunk2Size + 34; // was 36;
-  frec.seek(0);
-  frec.write("RIFF");
-  byte1 = ChunkSize & 0xff;
-  byte2 = (ChunkSize >> 8) & 0xff;
-  byte3 = (ChunkSize >> 16) & 0xff;
-  byte4 = (ChunkSize >> 24) & 0xff;  
-  frec.write(byte1);  frec.write(byte2);  frec.write(byte3);  frec.write(byte4);
-  frec.write("WAVE");
-  frec.write("fmt ");
-  byte1 = Subchunk1Size & 0xff;
-  byte2 = (Subchunk1Size >> 8) & 0xff;
-  byte3 = (Subchunk1Size >> 16) & 0xff;
-  byte4 = (Subchunk1Size >> 24) & 0xff;  
-  frec.write(byte1);  frec.write(byte2);  frec.write(byte3);  frec.write(byte4);
-  byte1 = AudioFormat & 0xff;
-  byte2 = (AudioFormat >> 8) & 0xff;
-  frec.write(byte1);  frec.write(byte2); 
-  byte1 = numChannels & 0xff;
-  byte2 = (numChannels >> 8) & 0xff;
-  frec.write(byte1);  frec.write(byte2); 
-  byte1 = sampleRate & 0xff;
-  byte2 = (sampleRate >> 8) & 0xff;
-  byte3 = (sampleRate >> 16) & 0xff;
-  byte4 = (sampleRate >> 24) & 0xff;  
-  frec.write(byte1);  frec.write(byte2);  frec.write(byte3);  frec.write(byte4);
-  byte1 = byteRate & 0xff;
-  byte2 = (byteRate >> 8) & 0xff;
-  byte3 = (byteRate >> 16) & 0xff;
-  byte4 = (byteRate >> 24) & 0xff;  
-  frec.write(byte1);  frec.write(byte2);  frec.write(byte3);  frec.write(byte4);
-  byte1 = blockAlign & 0xff;
-  byte2 = (blockAlign >> 8) & 0xff;
-  frec.write(byte1);  frec.write(byte2); 
-  byte1 = bitsPerSample & 0xff;
-  byte2 = (bitsPerSample >> 8) & 0xff;
-  frec.write(byte1);  frec.write(byte2); 
-  frec.write("data");
-  byte1 = Subchunk2Size & 0xff;
-  byte2 = (Subchunk2Size >> 8) & 0xff;
-  byte3 = (Subchunk2Size >> 16) & 0xff;
-  byte4 = (Subchunk2Size >> 24) & 0xff;  
-  frec.write(byte1);  frec.write(byte2);  frec.write(byte3);  frec.write(byte4);
-  frec.close();
-  Serial.println("header written"); 
-  Serial.print("Subchunk2: "); 
-  Serial.println(Subchunk2Size); 
-}
-
-void end_Beep(void) {
-          waveform1.frequency(523.25);
-        waveform1.amplitude(beep_volume);
-        wait(250);
-        waveform1.amplitude(0);
-        wait(250);
-        waveform1.amplitude(beep_volume);
-        wait(250);
-        waveform1.amplitude(0);
-        wait(250);
-        waveform1.amplitude(beep_volume);
-        wait(250);
-        waveform1.amplitude(0);
-        wait(250);
-        waveform1.amplitude(beep_volume);
-        wait(250);
-        waveform1.amplitude(0);
-}
-
-void print_mode(void) { // only for debugging
+void print_mode() {
   Serial.print("Mode switched to: ");
-  // Initialising, Ready, Prompting, Recording, Playing
-  if(mode == Mode::Ready)           Serial.println(" Ready");
-  else if(mode == Mode::Prompting)  Serial.println(" Prompting");
-  else if(mode == Mode::Recording)  Serial.println(" Recording");
-  else if(mode == Mode::Playing)    Serial.println(" Playing");
+  if(mode == Mode::Ready) Serial.println(" Ready");
+  else if(mode == Mode::Prompting) Serial.println(" Prompting");
+  else if(mode == Mode::Recording) Serial.println(" Recording");
+  else if(mode == Mode::Playing) Serial.println(" Playing");
+  else if(mode == Mode::Initialising) Serial.println(" Initialising");
+  else Serial.println(" Undefined");
+}
   else if(mode == Mode::Initialising)  Serial.println(" Initialising");
   else Serial.println(" Undefined");
 }


### PR DESCRIPTION
Increased AudioMemory from 60 to 120 to handle more audio data and avoid potential audio dropouts, ensuring smoother recordings.

Reduced microphone gain (micGain) to 2, down from the previous value, to minimize static and warbling sounds during recording.

Set the volume of the audio shield (volume) to 0.85 to avoid audio clipping during playback.

Increased debounce times for buttonRecord and buttonPlay from 20 ms to 40 ms. This helps ensure more reliable detection of button presses and releases.

Increased the number of audio blocks written to the SD card at once (from 16 to 32). This helps reduce the frequency of writes, making the recording process more efficient and potentially reducing interruptions.

Added a recording timeout of 10 minutes (RECORDING_TIMEOUT). This ensures that if the handset is left off the hook, the recording will automatically stop after 10 minutes, preventing excessive file sizes and SD card usage.

Adjusted the writeOutHeader() function for better handling of WAV file metadata, ensuring that the header data is correctly written after recording completes.

Maintained improvements to handle playback more reliably, allowing playback of the last recorded message and ensuring that playback mode is exited cleanly.